### PR TITLE
headless

### DIFF
--- a/examples/mesh.rs
+++ b/examples/mesh.rs
@@ -280,7 +280,7 @@ impl<'a> ApplicationHandler for App {
 
             WindowEvent::Resized(size) => {
                 let state = self.state.as_mut().unwrap();
-                state.lazy_vulkan.resize(size.width, size.height);
+                state.lazy_vulkan.resize(size);
             }
             WindowEvent::RedrawRequested => {
                 let lazy_vulkan = &mut state.lazy_vulkan;

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -131,7 +131,7 @@ impl<'a> ApplicationHandler for App {
 
             WindowEvent::Resized(size) => {
                 let state = self.state.as_mut().unwrap();
-                state.lazy_vulkan.resize(size.width, size.height);
+                state.lazy_vulkan.resize(size);
             }
             WindowEvent::RedrawRequested => {
                 let state = self.state.as_mut().unwrap();

--- a/src/context.rs
+++ b/src/context.rs
@@ -101,6 +101,16 @@ impl Context {
         }
     }
 
+    pub fn begin_command_buffer(&self) {
+        unsafe {
+            self.device.begin_command_buffer(
+                self.draw_command_buffer,
+                &vk::CommandBufferBeginInfo::default(),
+            )
+        }
+        .unwrap()
+    }
+
     pub fn find_memory_type_index(
         &self,
         requirements: &MemoryRequirements,

--- a/src/context.rs
+++ b/src/context.rs
@@ -37,7 +37,7 @@ impl Context {
         Context::new(core, device)
     }
 
-    pub(crate) fn new_headless(core: &Core) -> Context {
+    pub fn new_headless(core: &Core) -> Context {
         let instance = &core.instance;
         let physical_device = core.physical_device;
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -8,6 +8,7 @@ pub struct Core {
     pub instance: ash::Instance,
     pub physical_device: vk::PhysicalDevice,
 }
+
 impl Core {
     pub(crate) fn from_window(window: &winit::window::Window) -> Self {
         let entry = unsafe { ash::Entry::load().unwrap() };

--- a/src/core.rs
+++ b/src/core.rs
@@ -9,7 +9,7 @@ pub struct Core {
     pub physical_device: vk::PhysicalDevice,
 }
 impl Core {
-    pub fn from_window(window: &winit::window::Window) -> Self {
+    pub(crate) fn from_window(window: &winit::window::Window) -> Self {
         let entry = unsafe { ash::Entry::load().unwrap() };
 
         let display_handle = window.display_handle().unwrap().as_raw();

--- a/src/core.rs
+++ b/src/core.rs
@@ -72,8 +72,9 @@ impl Core {
     pub fn headless() -> Self {
         let entry = unsafe { ash::Entry::load().unwrap() };
 
-        #[allow(unused_mut)]
         let mut instance_extensions = Vec::new();
+
+        instance_extensions.push(ash::ext::debug_utils::NAME.as_ptr());
         let version;
         let instance_create_flags;
 

--- a/src/depth_buffer.rs
+++ b/src/depth_buffer.rs
@@ -76,8 +76,8 @@ impl DepthBuffer {
         }
     }
 
-    pub fn validate(&mut self, context: &Context, swapchain: &Swapchain) {
-        if swapchain.extent == self.extent {
+    pub fn resize(&mut self, context: &Context, new_extent: vk::Extent2D) {
+        if new_extent == self.extent {
             // Sizes are identical, nothing to do.
             return;
         }
@@ -85,7 +85,7 @@ impl DepthBuffer {
         unsafe { context.device.device_wait_idle().unwrap() };
 
         unsafe { self.destroy(context) };
-        *self = DepthBuffer::new(context, swapchain.extent)
+        *self = DepthBuffer::new(context, new_extent)
     }
 
     unsafe fn destroy(&self, context: &Context) {

--- a/src/headless_swapchain.rs
+++ b/src/headless_swapchain.rs
@@ -6,7 +6,7 @@ pub struct HeadlessSwapchain {
     pub context: Arc<Context>,
     pub extent: vk::Extent2D,
     pub format: vk::Format,
-    image: HeadlessSwapchainImage,
+    pub image: HeadlessSwapchainImage,
     render_complete: vk::Semaphore,
 }
 
@@ -50,10 +50,11 @@ impl HeadlessSwapchain {
     }
 }
 
-struct HeadlessSwapchainImage {
-    image: vk::Image,
-    memory: vk::DeviceMemory,
-    view: vk::ImageView,
+#[derive(Debug, Clone)]
+pub struct HeadlessSwapchainImage {
+    pub image: vk::Image,
+    pub memory: vk::DeviceMemory,
+    pub view: vk::ImageView,
 }
 
 impl HeadlessSwapchainImage {
@@ -130,6 +131,7 @@ impl HeadlessSwapchainImage {
             device.free_memory(self.memory, None);
         }
 
-        *self = Self::new(context, new_extent, format)
+        *self = Self::new(context, new_extent, format);
+        log::debug!("Resized! Image: {:?}", self.image);
     }
 }

--- a/src/headless_swapchain.rs
+++ b/src/headless_swapchain.rs
@@ -1,0 +1,135 @@
+use crate::{swapchain::Drawable, Context, FULL_IMAGE};
+use ash::vk::{self};
+use std::sync::Arc;
+
+pub struct HeadlessSwapchain {
+    pub context: Arc<Context>,
+    pub extent: vk::Extent2D,
+    pub format: vk::Format,
+    image: HeadlessSwapchainImage,
+    render_complete: vk::Semaphore,
+}
+
+impl HeadlessSwapchain {
+    pub(crate) fn new(context: Arc<Context>, extent: vk::Extent2D, format: vk::Format) -> Self {
+        let image = HeadlessSwapchainImage::new(&context, extent, format);
+        let render_complete = unsafe {
+            context
+                .device
+                .create_semaphore(&vk::SemaphoreCreateInfo::default(), None)
+        }
+        .unwrap();
+
+        Self {
+            context,
+            extent,
+            format,
+            image,
+            render_complete,
+        }
+    }
+
+    pub(crate) fn resize(&mut self, new_extent: vk::Extent2D) {
+        if self.extent == new_extent {
+            return;
+        }
+
+        self.extent = new_extent;
+        self.image.resize(&self.context, self.extent, self.format);
+    }
+
+    pub(crate) fn get_drawable(&self) -> Drawable {
+        Drawable {
+            image: self.image.image,
+            view: self.image.view,
+            image_available: None,
+            rendering_complete: self.render_complete,
+            index: 0,
+            extent: self.extent,
+        }
+    }
+}
+
+struct HeadlessSwapchainImage {
+    image: vk::Image,
+    memory: vk::DeviceMemory,
+    view: vk::ImageView,
+}
+
+impl HeadlessSwapchainImage {
+    fn new(context: &Context, extent: vk::Extent2D, format: vk::Format) -> HeadlessSwapchainImage {
+        let device = &context.device;
+
+        let image = unsafe {
+            device.create_image(
+                &vk::ImageCreateInfo::default()
+                    .array_layers(1)
+                    .mip_levels(1)
+                    .image_type(vk::ImageType::TYPE_2D)
+                    .samples(vk::SampleCountFlags::TYPE_1)
+                    .tiling(vk::ImageTiling::OPTIMAL)
+                    .usage(vk::ImageUsageFlags::COLOR_ATTACHMENT | vk::ImageUsageFlags::SAMPLED)
+                    .sharing_mode(vk::SharingMode::EXCLUSIVE)
+                    .initial_layout(vk::ImageLayout::UNDEFINED)
+                    .extent(extent.into())
+                    .format(format),
+                None,
+            )
+        }
+        .unwrap();
+
+        let memory_requirements = unsafe { device.get_image_memory_requirements(image) };
+
+        let memory_type_index = context
+            .find_memory_type_index(&memory_requirements, vk::MemoryPropertyFlags::DEVICE_LOCAL)
+            .expect("No memory type index for depth buffer - impossible");
+
+        let memory = unsafe {
+            device.allocate_memory(
+                &vk::MemoryAllocateInfo::default()
+                    .allocation_size(memory_requirements.size)
+                    .memory_type_index(memory_type_index),
+                None,
+            )
+        }
+        .expect("Failed to allocate memory - impossible");
+
+        unsafe {
+            device.bind_image_memory2(&[vk::BindImageMemoryInfo::default()
+                .image(image)
+                .memory(memory)])
+        }
+        .unwrap();
+
+        let view = unsafe {
+            device.create_image_view(
+                &vk::ImageViewCreateInfo::default()
+                    .image(image)
+                    .view_type(vk::ImageViewType::TYPE_2D)
+                    .format(format)
+                    .components(vk::ComponentMapping::default())
+                    .subresource_range(FULL_IMAGE),
+                None,
+            )
+        }
+        .unwrap();
+
+        HeadlessSwapchainImage {
+            image,
+            memory,
+            view,
+        }
+    }
+
+    pub fn resize(&mut self, context: &Context, new_extent: vk::Extent2D, format: vk::Format) {
+        let device = &context.device;
+        unsafe {
+            device.device_wait_idle().unwrap();
+            device.destroy_image_view(self.view, None);
+            device.destroy_image(self.image, None);
+            device.free_memory(self.memory, None);
+        }
+
+        *self = Self::new(context, new_extent, format)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub struct LazyVulkan<SF: StateFamily> {
 impl<SF: StateFamily> LazyVulkan<SF> {
     pub fn from_window(window: &winit::window::Window) -> Self {
         let core = Core::from_window(window);
-        let context = Arc::new(Context::new(&core));
+        let context = Arc::new(Context::new_from_window(&core));
         let swapchain = Swapchain::new(&context.device, &core, window, vk::SwapchainKHR::null());
         let renderer = Renderer::from_swapchain(context.clone(), swapchain);
 
@@ -49,7 +49,7 @@ impl<SF: StateFamily> LazyVulkan<SF> {
 
     pub fn headless() -> Self {
         let core = Core::headless();
-        let context = Arc::new(Context::new(&core));
+        let context = Arc::new(Context::new_headless(&core));
         let renderer = Renderer::headless(context.clone());
 
         LazyVulkan {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+pub use crate::swapchain::Drawable;
 pub use allocator::{Allocator, BufferAllocation, SlabUpload, TransferToken};
 pub use ash;
+use ash::vk;
 pub use context::Context;
 pub use core::Core;
 pub use draw_params::DrawParams;
@@ -8,8 +10,6 @@ pub use pipeline::Pipeline;
 pub use renderer::Renderer;
 use std::sync::Arc;
 pub use sub_renderer::{StateFamily, SubRenderer};
-
-use ash::vk;
 use swapchain::Swapchain;
 
 mod allocator;
@@ -61,7 +61,18 @@ impl<SF: StateFamily> LazyVulkan<SF> {
     }
 
     pub fn draw<'s>(&mut self, state: &SF::For<'s>) {
-        self.renderer.draw(state);
+        let drawable = self.renderer.get_drawable();
+        self.renderer.begin_command_buffer();
+        self.renderer.draw(state, &drawable);
+    }
+
+    pub fn get_drawable(&mut self) -> Drawable {
+        let drawable = self.renderer.get_drawable();
+        drawable
+    }
+
+    pub fn draw_to_drawable<'s>(&mut self, state: &SF::For<'s>, drawable: &Drawable) {
+        self.renderer.draw(state, &drawable);
     }
 
     pub fn add_sub_renderer(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,11 @@ impl<SF: StateFamily> LazyVulkan<SF> {
         let drawable = self.renderer.get_drawable();
         self.renderer.begin_command_buffer();
         self.renderer.draw(state, &drawable);
+        self.renderer.submit_and_present(drawable);
+    }
+
+    pub fn begin_commands(&mut self) {
+        self.renderer.begin_command_buffer();
     }
 
     pub fn get_drawable(&mut self) -> Drawable {
@@ -80,6 +85,10 @@ impl<SF: StateFamily> LazyVulkan<SF> {
         sub_renderer: Box<dyn for<'s> SubRenderer<'s, State = SF::For<'s>>>,
     ) {
         self.renderer.sub_renderers.push(sub_renderer);
+    }
+
+    pub fn submit_and_present(&mut self, drawable: Drawable) {
+        self.renderer.submit_and_present(drawable);
     }
 
     pub fn resize(&mut self, width: u32, height: u32) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use ash::vk;
 pub use context::Context;
 pub use core::Core;
 pub use draw_params::DrawParams;
+pub use headless_swapchain::HeadlessSwapchainImage;
 pub use image_manager::{Image, ImageManager};
 pub use pipeline::Pipeline;
 pub use renderer::Renderer;
@@ -91,8 +92,8 @@ impl<SF: StateFamily> LazyVulkan<SF> {
         self.renderer.submit_and_present(drawable);
     }
 
-    pub fn resize(&mut self, width: u32, height: u32) {
-        self.renderer.resize(vk::Extent2D { width, height });
+    pub fn resize(&mut self, new_extent: impl IntoExtent) {
+        self.renderer.resize(new_extent.into_extent());
     }
 }
 
@@ -103,3 +104,22 @@ pub const FULL_IMAGE: vk::ImageSubresourceRange = vk::ImageSubresourceRange {
     base_array_layer: 0,
     layer_count: vk::REMAINING_ARRAY_LAYERS,
 };
+
+pub trait IntoExtent {
+    fn into_extent(self) -> vk::Extent2D;
+}
+
+impl IntoExtent for vk::Extent2D {
+    fn into_extent(self) -> vk::Extent2D {
+        self
+    }
+}
+
+impl IntoExtent for winit::dpi::PhysicalSize<u32> {
+    fn into_extent(self) -> vk::Extent2D {
+        vk::Extent2D {
+            width: self.width,
+            height: self.height,
+        }
+    }
+}

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -122,13 +122,15 @@ impl<SF: StateFamily> Renderer<SF> {
             subrenderer.draw_layer(state, &self.context, params);
             self.context.end_marker();
         }
+    }
 
+    pub fn submit_and_present(&mut self, drawable: Drawable) {
         // Transition the colour image to the present layout and submit all work
-        self.submit_rendering(drawable);
+        self.submit_rendering(&drawable);
 
         // Present
         if let SwapchainBackend::WSI(swapchain) = &self.swapchain {
-            swapchain.present(drawable, self.context.graphics_queue)
+            swapchain.present(drawable, self.context.graphics_queue);
         }
     }
 
@@ -283,7 +285,7 @@ impl<SF: StateFamily> Renderer<SF> {
         }
     }
 
-    fn submit_rendering(&self, drawable: Drawable) {
+    fn submit_rendering(&self, drawable: &Drawable) {
         let context = &self.context;
         let device = &context.device;
         let queue = context.graphics_queue;

--- a/src/swapchain.rs
+++ b/src/swapchain.rs
@@ -118,7 +118,7 @@ impl Swapchain {
         Some(Drawable {
             image: self.images[index as usize],
             view: self.image_views[index as usize],
-            image_available,
+            image_available: Some(image_available),
             index,
             extent: self.extent,
             rendering_complete: self.rendering_complete_semaphores[index as usize],
@@ -233,7 +233,7 @@ fn build_swapchain(
 pub struct Drawable {
     pub image: vk::Image,
     pub view: vk::ImageView,
-    pub image_available: vk::Semaphore,
+    pub image_available: Option<vk::Semaphore>,
     pub rendering_complete: vk::Semaphore,
     pub index: u32,
     pub extent: vk::Extent2D,


### PR DESCRIPTION
Adds support for running renderers in "headless" mode, where they write to an off screen buffer
rather than to the swapchain on a window.

This also exposes more of the render lifecycle to the outside world, allowing for multiple
LazyVulkan instances to be chained together.

All in all, pretty neat.
